### PR TITLE
This pull request should greatly boost page speed 

### DIFF
--- a/vol/static/js/index-loader.js
+++ b/vol/static/js/index-loader.js
@@ -1,0 +1,14 @@
+[
+  'https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js',
+  'https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js',
+  'https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js',
+  'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js',
+  'https://cdnjs.cloudflare.com/ajax/libs/typeahead.js/0.11.1/typeahead.bundle.min.js',
+  'https://cdnjs.cloudflare.com/ajax/libs/typeahead.js/0.11.1/bloodhound.min.js',
+  '/static/js/index.js'
+].forEach(function(src) {
+  var script = document.createElement('script');
+  script.src = src;
+  script.async = false;
+  document.head.appendChild(script);
+});

--- a/vol/templates/vol/base.html
+++ b/vol/templates/vol/base.html
@@ -75,18 +75,12 @@
 
 </div>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-{#<script async src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js"></script>#}
-<script async src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"
-        integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4"
-        crossorigin="anonymous"></script>
-
 <div class="vol-template" id="content">
 
     {% block content %}{% endblock %}
 </div>
 
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js"></script>
+
 
 {% include "vol/footer.html" %}
 

--- a/vol/templates/vol/index.html
+++ b/vol/templates/vol/index.html
@@ -27,7 +27,5 @@
         </form>
     </div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/typeahead.js/0.11.1/typeahead.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/typeahead.js/0.11.1/bloodhound.min.js"></script>
-    <script src="{% static "js/index.js" %}"></script>
+    <script async src="{% static "js/index-loader.js" %}"></script>
 {% endblock %}


### PR DESCRIPTION
This pull request should greatly boost page speed  (without breaking the site).

Assuming that all JS files are currently only required to make the typeahead inputs
on the index page work, we can make the following optimisation, which moves loading
and parsing out of the entire path to the first DOMContentLoaded event.

We simply require a single async JS file, which moves the file out of the critical
path. The file will then load the remaining scripts, making sure they are loaded
and parsed in order.

Be aware that on slow networks the user might run into cases where the input boxes
are not yet enhanced with TypeScript and won't show autocomplete. I guess this falls
under progressive enhancement.

Admittedly, the current solution is a bit primitive, but it will do for now. When
the page dependencies get more complex, you might want to introduce a proper
dependency loader instead.

Closes #54

<img width="1139" alt="screen shot 2017-11-01 at 19 45 42" src="https://user-images.githubusercontent.com/1471561/32291427-4ffacc1c-bf3d-11e7-9fd6-c321b72a721a.png">
