### PR TITLE
Allow PRs from forks to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ services:
 env:
   global:
   - DATABASE_URL=postgres://postgres@localhost/test_db
-  - secure: DVrETAPbM3RXmPrBCstxSeI1ZTrHrAr/WBOuXis8QQec0wdWqc1VczpSqvK8dc4QmQybYiCbjKEMw/r9HUh9blpPAZ0QTS3GfCwW+qwZ4qw/IQ2lH4Lf1USt6IltecdYQZkX+mOcmo+UqOeGnw0KSKJJOYppXza1/bq/moGt4i75eEsVGO9TWtUscIH/7LJW1TUWhtlS869gJczw2KvK7grAFwuuA+x67nIBPoxAyKLfHm2kND/IqNYGDwlBcIpRqjPD0QcLvdihycyGdU9QeEFqSBLo0XzYJxSpKYhiECRPO98hRLLhSTNh5enrCp6Aq0cqWQpaWYzyMnNN92AHOiT4JmGSwR8iAlNi8h5g03fZhxC0vy42x3EitpaR5oM32gLdSwMIuWYPiVS33/O46yA9dPEktHRSe7JqiXzoK2KHVITHthPgADfGwikbwonfoamvTcvss2FWyUQPrURLMrkdKI9pTtkWrG/X7Xw+y/LXCGoOpgrzkIHV/8x8iWRd6je/Ap90OqUO/Z4mICPz9pMuS6mmlz/NHi7DvLP+8TWGZ15+5jTebeskv6ZzWCIx62ViVVYGsBugVkJaTprSAIuGiXP0B4qpo3T+olQcREDrOX6BP0r/qvFgVkVORJPtsGCc2rhwnR7OHwcnLp9KsoZHMa/8c1qv5r7rnSbhb7E=
+  - DJANGO_SECRET_KEY="super secret"
 deploy:
   provider: heroku
   api_key:


### PR DESCRIPTION
Secret key variable for Django does not need to be secret in Travis. The one in Heroku is obviously different.